### PR TITLE
Tweak<Date> support with DatePicker UI

### DIFF
--- a/SwiftTweaks.xcodeproj/project.pbxproj
+++ b/SwiftTweaks.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		AA356AF51EB3C5FC0063F4E2 /* TweakAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA356AEF1EB3B5A90063F4E2 /* TweakAction.swift */; };
 		B0E03A551CFF818900BFB1E6 /* TweakDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E03A541CFF818900BFB1E6 /* TweakDebug.swift */; };
 		B0E03A571CFF86E900BFB1E6 /* TweakDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E03A541CFF818900BFB1E6 /* TweakDebug.swift */; };
+		B26DF0C224EBF97D00546B6B /* DatePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26DF0C124EBF97D00546B6B /* DatePickerViewController.swift */; };
 		D5CE0BDC1DC7DFC200F79235 /* TweakBindingIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE0BDB1DC7DFC200F79235 /* TweakBindingIdentifier.swift */; };
 		D5CE0BDE1DC7E04A00F79235 /* MultiTweakBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE0BDD1DC7E04A00F79235 /* MultiTweakBinding.swift */; };
 		D5CE0BE01DC7E0D600F79235 /* MultiTweakBindingIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE0BDF1DC7E0D600F79235 /* MultiTweakBindingIdentifier.swift */; };
@@ -172,6 +173,7 @@
 		AA356AEF1EB3B5A90063F4E2 /* TweakAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakAction.swift; sourceTree = "<group>"; };
 		AA356AF31EB3C5B40063F4E2 /* TweakActionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakActionTests.swift; sourceTree = "<group>"; };
 		B0E03A541CFF818900BFB1E6 /* TweakDebug.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakDebug.swift; sourceTree = "<group>"; };
+		B26DF0C124EBF97D00546B6B /* DatePickerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatePickerViewController.swift; sourceTree = "<group>"; };
 		D5CE0BDB1DC7DFC200F79235 /* TweakBindingIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweakBindingIdentifier.swift; sourceTree = "<group>"; };
 		D5CE0BDD1DC7E04A00F79235 /* MultiTweakBinding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiTweakBinding.swift; sourceTree = "<group>"; };
 		D5CE0BDF1DC7E0D600F79235 /* MultiTweakBindingIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiTweakBindingIdentifier.swift; sourceTree = "<group>"; };
@@ -249,6 +251,7 @@
 		9356CD201BF16E2300D0BBD1 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
+				B26DF0C124EBF97D00546B6B /* DatePickerViewController.swift */,
 				9345EC081BF2A0490086AB5D /* TweaksRootViewController.swift */,
 				939CB70E218CFE570041E3EA /* HapticsPlayer.swift */,
 				9356CD1E1BF16DFA00D0BBD1 /* TweaksCollectionsListViewController.swift */,
@@ -524,6 +527,7 @@
 				933223541CB83F0C002D586B /* BasicAnimationTweakTemplate.swift in Sources */,
 				93E777041BED4BBD003F0DE2 /* TweakLibrary.swift in Sources */,
 				D5CE0BDE1DC7E04A00F79235 /* MultiTweakBinding.swift in Sources */,
+				B26DF0C224EBF97D00546B6B /* DatePickerViewController.swift in Sources */,
 				933223561CB8403E002D586B /* UIView+BasicAnimationTweakTemplate.swift in Sources */,
 				937962951BFE7B2C0046E4CE /* TweakStore+Sharing.swift in Sources */,
 				931A24741BFA7A3800E40192 /* TweakColorCell.swift in Sources */,

--- a/SwiftTweaks/DatePickerViewController.swift
+++ b/SwiftTweaks/DatePickerViewController.swift
@@ -1,0 +1,214 @@
+//
+//  DatePickerViewController.swift
+//  SwiftTweaks
+//
+//  Created by Antti Vekkeli on 11.8.2020.
+//
+
+import Foundation
+import UIKit
+
+internal protocol DatePickerViewControllerDelegate {
+    func datePickerViewControllerDidPressDismissButton(_ tweakSelectionViewController: DatePickerViewController)
+}
+
+/// Allows the user to select an option for a StringListOption value.
+internal class DatePickerViewController: UIViewController {
+    private let delegate: DatePickerViewControllerDelegate
+    
+    private let tweak: Tweak<Date>
+    private let tweakStore: TweakStore
+    
+    private var dateTimePickerView: DateTimePickerView!
+    
+    init(anyTweak: AnyTweak, tweakStore: TweakStore, delegate: DatePickerViewControllerDelegate) {
+        assert(anyTweak.tweakViewDataType == .date, "Can only edit Date in this UI.")
+        self.dateTimePickerView = DateTimePickerView(anyTweak: anyTweak, tweakStore: tweakStore)
+        self.tweak = anyTweak.tweak as! Tweak<Date>
+        self.tweakStore = tweakStore
+        self.delegate = delegate
+        
+        super.init(nibName: nil, bundle: nil)
+        
+        title = tweak.tweakName
+        toolbarItems = [
+            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+            UIBarButtonItem(title: TweaksViewController.dismissButtonTitle, style: .done, target: self, action: #selector(self.dismissButtonTapped))
+        ]
+        
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Reset", style: .plain, target: self, action: #selector(DatePickerViewController.restoreDefaultValue))
+        self.navigationItem.rightBarButtonItem?.tintColor = AppTheme.Colors.controlDestructive
+        
+        view.backgroundColor = .white
+        edgesForExtendedLayout = []
+        
+        view.addSubview(dateTimePickerView)
+        dateTimePickerView.frame = view.bounds
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+        
+    // MARK: Events
+    
+    @objc private func restoreDefaultValue() {
+        let confirmationAlert = UIAlertController(title: "Reset This Tweak?", message: "Your other tweaks will be left alone. The default value is \(tweak.defaultValue)", preferredStyle: .actionSheet)
+        confirmationAlert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        confirmationAlert.addAction(UIAlertAction(title: "Reset Tweak", style: .destructive, handler: { _ in
+            self.dateTimePickerView.setDateTime(self.tweak.defaultValue)
+        }))
+        present(confirmationAlert, animated: true, completion: nil)
+    }
+    
+    @objc private func dismissButtonTapped() {
+        delegate.datePickerViewControllerDidPressDismissButton(self)
+    }
+}
+
+
+class DateTimePickerView: UIView {
+    
+    private let tweak: Tweak<Date>
+    private let tweakStore: TweakStore
+    
+    private(set) var dateTime: Date {
+        didSet {
+            tweakStore.setValue(
+                .date(value: dateTime,
+                    defaultValue: tweak.defaultValue,
+                    min: tweak.minimumValue,
+                    max: tweak.maximumValue
+                ),
+                forTweak: AnyTweak(tweak: tweak)
+            )
+        }
+    }
+    
+    func setDateTime(_ dateTime: Date) {
+        var newDateTime = dateTime
+        
+        if let max = tweak.maximumValue, max <= newDateTime {
+            newDateTime = max
+        } else if let min = tweak.minimumValue, min >= newDateTime {
+            newDateTime = min
+        }
+        
+        self.dateTime = newDateTime
+        
+        if timePicker.date != newDateTime {
+            timePicker.date = newDateTime
+        }
+        if datePicker.date != newDateTime {
+            datePicker.date = newDateTime
+        }
+    }
+    
+    private let dateFormatter: DateFormatter = {
+        let formatter = TweakDateFormatter.dateFormatter()
+        formatter.timeStyle = .none
+        return formatter
+    }()
+    
+    private let timeFormatter: DateFormatter = {
+        let formatter = TweakDateFormatter.dateFormatter()
+        formatter.dateStyle = .none
+        return formatter
+    }()
+        
+    fileprivate var timeLabel: UILabel = {
+        let label = UILabel()
+        label.backgroundColor = UIColor.groupTableViewBackground
+        label.textColor = AppTheme.Colors.sectionHeaderTitleColor
+        label.text = "Time"
+        return label
+    }()
+    
+    fileprivate var dateLabel: UILabel = {
+        let label = UILabel()
+        label.backgroundColor = UIColor.groupTableViewBackground
+        label.textColor = AppTheme.Colors.sectionHeaderTitleColor
+        label.text = "Date"
+        return label
+    }()
+    
+    fileprivate var timePicker: UIDatePicker = {
+        let picker = UIDatePicker()
+        picker.backgroundColor = .white
+        picker.datePickerMode = .time
+        picker.addTarget(self, action: #selector(datePickerDidChangeValue(_:)), for: .valueChanged)
+        return picker
+    }()
+    
+    fileprivate var datePicker: UIDatePicker = {
+        let picker = UIDatePicker()
+        picker.backgroundColor = .white
+        picker.datePickerMode = .date
+        picker.addTarget(self, action: #selector(datePickerDidChangeValue(_:)), for: .valueChanged)
+        return picker
+    }()
+    
+    init(anyTweak: AnyTweak, tweakStore: TweakStore) {
+        assert(anyTweak.tweakViewDataType == .date, "Can only edit Date in this UI.")
+        self.tweak = anyTweak.tweak as! Tweak<Date>
+        self.tweakStore = tweakStore
+        self.dateTime = tweakStore.currentValueForTweak(self.tweak)
+        
+        super.init(frame: .zero)
+        backgroundColor = UIColor.groupTableViewBackground
+        
+        addSubview(dateLabel)
+        addSubview(datePicker)
+        addSubview(timeLabel)
+        addSubview(timePicker)
+        
+        setDateTime(dateTime) // Update pickers
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+        
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        dateLabel.frame = CGRect(
+            origin: CGPoint(x: 16, y: bounds.minY),
+            size: CGSize(width: bounds.width, height: 44))
+        datePicker.frame = CGRect(
+            origin: CGPoint(x: 0, y: dateLabel.frame.maxY),
+            size: CGSize(width: bounds.width, height: 160))
+        timeLabel.frame = CGRect(
+            origin: CGPoint(x: 16, y: datePicker.frame.maxY),
+            size: CGSize(width: bounds.width, height: 44))
+        timePicker.frame = CGRect(
+            origin: CGPoint(x: 0, y: timeLabel.frame.maxY),
+            size: CGSize(width: bounds.width, height: 160))
+    }
+    
+    @objc func datePickerDidChangeValue(_ picker: UIDatePicker) {
+        if picker == datePicker {
+            setDateTime(combine(date: picker.date, time: dateTime) ?? picker.date)
+        }
+        if picker == timePicker {
+            setDateTime(combine(date: dateTime, time: picker.date) ?? picker.date)
+        }
+    }
+    
+    private func combine(date: Date, time: Date) -> Date? {
+        let calendar = NSCalendar.current
+        
+        let dateComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        let timeComponents = calendar.dateComponents([.hour, .minute, .second], from: time)
+        
+        var components = DateComponents()
+        components.year = dateComponents.year
+        components.month = dateComponents.month
+        components.day = dateComponents.day
+        components.hour = timeComponents.hour
+        components.minute = timeComponents.minute
+        components.second = timeComponents.second
+        
+        return calendar.date(from: components)
+    }
+}

--- a/SwiftTweaks/FloatingTweakGroupViewController.swift
+++ b/SwiftTweaks/FloatingTweakGroupViewController.swift
@@ -32,7 +32,7 @@ internal final class FloatingTweakGroupViewController: UIViewController {
 		switch tweak.tweakViewDataType {
 		case .boolean, .integer, .cgFloat, .double, .action:
 			return true
-		case .uiColor, .stringList, .string:
+		case .uiColor, .stringList, .string, .date:
 			return false
 		}
 	}
@@ -341,7 +341,7 @@ extension FloatingTweakGroupViewController: UITableViewDelegate {
 			if let actionTweak = tweak.tweak as? Tweak<TweakAction> {            
 				actionTweak.defaultValue.evaluateAllClosures()
 			}
-		case .boolean, .cgFloat, .double, .integer, .string, .stringList, .uiColor:
+		case .boolean, .cgFloat, .double, .integer, .string, .stringList, .uiColor, .date:
 			break
 		}
 		self.tableView.deselectRow(at: indexPath, animated: true)

--- a/SwiftTweaks/Tweak.swift
+++ b/SwiftTweaks/Tweak.swift
@@ -163,6 +163,10 @@ extension Tweak: TweakType {
 			return .action(
 				defaultValue: defaultValue as! TweakAction
 			)
+		case .date:
+			return .date(defaultValue: defaultValue as! Date,
+						 min: minimumValue as? Date,
+						 max: maximumValue as? Date)
 		}
 	}
 

--- a/SwiftTweaks/TweakBinding.swift
+++ b/SwiftTweaks/TweakBinding.swift
@@ -21,7 +21,7 @@ internal struct TweakBinding<T: TweakableType>: TweakBindingType{
 
 	func applyBindingWithValue(_ value: TweakableType) {
 		switch type(of: value).tweakViewDataType {
-		case .boolean, .integer, .cgFloat, .action, .double, .uiColor, .string, .stringList:
+		case .boolean, .integer, .cgFloat, .action, .double, .uiColor, .string, .stringList, .date:
 			binding(value as! T)
 		}
 	}

--- a/SwiftTweaks/TweakCollectionViewController.swift
+++ b/SwiftTweaks/TweakCollectionViewController.swift
@@ -143,6 +143,9 @@ extension TweakCollectionViewController: UITableViewDelegate {
 			cell.startEditingTextField()
 		case .boolean:
 			break
+		case .date:
+			let datePickerVC = DatePickerViewController(anyTweak: tweak, tweakStore: tweakStore, delegate: self)
+			navigationController?.pushViewController(datePickerVC, animated: true)
 		}
 	}
     
@@ -212,6 +215,12 @@ extension TweakCollectionViewController: TweakColorEditViewControllerDelegate {
 
 extension TweakCollectionViewController: StringOptionViewControllerDelegate {
 	func stringOptionViewControllerDidPressDismissButton(_ tweakSelectionViewController: StringOptionViewController) {
+		self.delegate.tweakCollectionViewControllerDidPressDismissButton(self)
+	}
+}
+
+extension TweakCollectionViewController: DatePickerViewControllerDelegate {
+	func datePickerViewControllerDidPressDismissButton(_ tweakSelectionViewController: DatePickerViewController) {
 		self.delegate.tweakCollectionViewControllerDidPressDismissButton(self)
 	}
 }

--- a/SwiftTweaks/TweakPersistency.swift
+++ b/SwiftTweaks/TweakPersistency.swift
@@ -179,6 +179,7 @@ private final class TweakDiskPersistency {
 				}
 				return StringOption(value: stringOptionString)
 			case .action: return nil
+			case .date: return anyObject as? Date
 			}
 		}
 	}
@@ -196,6 +197,7 @@ private extension TweakViewDataType {
 		case .string: return "string"
 		case .stringList: return "stringlist"
 		case .action: return "action"
+		case .date: return "date"
 		}
 	}
 }
@@ -212,6 +214,7 @@ private extension TweakableType {
 			case .string: return self as! NSString
 			case .stringList: return (self as! StringOption).value as AnyObject
 			case .action: return true as AnyObject
+			case .date: return self as! Date as AnyObject
 		}
 	}
 }

--- a/SwiftTweaks/TweakStore.swift
+++ b/SwiftTweaks/TweakStore.swift
@@ -162,6 +162,9 @@ public final class TweakStore {
 		case let .action(defaultValue: defaultValue):
 			let currentValue = cachedValue as? TweakAction ?? defaultValue
 			return .action(value: currentValue)
+		case let .date(defaultValue: defaultValue, min: min, max: max):
+			let currentValue = cachedValue as? Date ?? defaultValue
+			return .date(value: currentValue, defaultValue: defaultValue, min: min, max: max)
 		}
 	}
 	

--- a/SwiftTweaks/TweakViewData.swift
+++ b/SwiftTweaks/TweakViewData.swift
@@ -18,6 +18,7 @@ internal enum TweakViewData {
 	case string(value: String, defaultValue: String)
 	case stringList(value: StringOption, defaultValue: StringOption, options: [StringOption])
 	case action(value: TweakAction)
+	case date(value: Date, defaultValue: Date, min: Date?, max: Date?)
 
 	init<T: TweakableType>(type: TweakViewDataType, value: T, defaultValue: T, minimum: T?, maximum: T?, stepSize: T?, options: [T]?) {
 		switch type {
@@ -40,6 +41,8 @@ internal enum TweakViewData {
 			self = .stringList(value: value as! StringOption, defaultValue: defaultValue as! StringOption, options: options!.map { $0 as! StringOption })
 		case .action:
 			self = .action(value: value as! TweakAction)
+		case .date:
+			self = .date(value: value as! Date, defaultValue: defaultValue as! Date, min: minimum as? Date, max: maximum as? Date)
 		}
 	}
 
@@ -61,13 +64,15 @@ internal enum TweakViewData {
 			return stringValue
 		case let .action(value: value):
 			return value
+		case let .date(value: dateValue, _, _, _):
+			return dateValue
 		}
 	}
 
 	/// For signedNumberType tweaks, this is a shortcut to `value` as a Double
 	var doubleValue: Double? {
 		switch self {
-		case .boolean, .color, .action, .string, .stringList:
+		case .boolean, .color, .action, .string, .stringList, .date:
 			return nil
 		case let .integer(value: intValue, _, _, _, _):
 			return Double(intValue)
@@ -106,6 +111,9 @@ internal enum TweakViewData {
 		case .action:
 			string = ""
 			differsFromDefault = false
+		case let .date(value: value, defaultValue: defaultValue, _, _):
+			string = TweakDateFormatter.dateFormatter().string(from: value)
+			differsFromDefault = value != defaultValue
 		}
 		return (string, differsFromDefault)
 	}
@@ -114,7 +122,7 @@ internal enum TweakViewData {
 		switch self {
 		case .integer, .float, .doubleTweak:
 			return true
-		case .boolean, .color, .action, .string, .stringList:
+		case .boolean, .color, .action, .string, .stringList, .date:
 			return false
 		}
 	}
@@ -154,7 +162,7 @@ internal enum TweakViewData {
 		let step: Double?
 		let isInteger: Bool
 		switch self {
-		case .boolean, .color, .action, .stringList, .string:
+		case .boolean, .color, .action, .stringList, .string, .date:
 			return nil
 
 		case let .integer(intValue, intDefaultValue, intMin, intMax, intStep):
@@ -229,5 +237,15 @@ internal enum TweakViewData {
 		resultStep = step ?? resultStep
 
 		return (resultMin, resultMax, resultStep)
+	}
+}
+
+struct TweakDateFormatter {
+	static func dateFormatter() -> DateFormatter {
+		let formatter = DateFormatter()
+		formatter.dateStyle = .short
+		formatter.timeStyle = .short
+		formatter.locale = Locale.current
+		return formatter
 	}
 }

--- a/SwiftTweaks/TweakableType.swift
+++ b/SwiftTweaks/TweakableType.swift
@@ -27,9 +27,10 @@ public enum TweakViewDataType {
 	case string
 	case stringList
 	case action
+	case date
 
 	public static let allTypes: [TweakViewDataType] = [
-		.boolean, .integer, .cgFloat, .action, .double, .uiColor, .string, .stringList, 
+		.boolean, .integer, .cgFloat, .action, .double, .uiColor, .string, .stringList, date
 	]
 }
 
@@ -45,6 +46,7 @@ public enum TweakDefaultData {
 	case string(defaultValue: String)
 	case stringList(defaultValue: StringOption, options: [StringOption])
 	case action(defaultValue: TweakAction)
+	case date(defaultValue: Date, min: Date?, max: Date?)
 }
 
 // MARK: Types that conform to TweakableType
@@ -102,5 +104,11 @@ extension UIColor: TweakableType {
 extension String: TweakableType {
 	public static var tweakViewDataType: TweakViewDataType {
 		return .string
+	}
+}
+
+extension Date: TweakableType {
+	public static var tweakViewDataType: TweakViewDataType {
+		return .date
 	}
 }


### PR DESCRIPTION
This pull request adds support for `Tweak<Date>`.
Usage is similar as with other Tweak types. Date and time are selected with `DatePickerViewController`.

```
static let dateTweak: Tweak<Date> = Tweak<Date>("Date Example", "Date Group", "Date Tweak", defaultValue: Date(timeIntervalSinceReferenceDate: 0), min: nil, max: nil)

```
![date-tweak-example](https://user-images.githubusercontent.com/7485508/90512541-fdd91e80-e166-11ea-8d37-dec4c10bcb33.gif)

