### PR TITLE
Bugfix for DateTweak not updating UIPickerView

### DIFF
--- a/SwiftTweaks/DatePickerViewController.swift
+++ b/SwiftTweaks/DatePickerViewController.swift
@@ -87,13 +87,6 @@ class DateTimePickerView: UIView {
     
     func setDateTime(_ dateTime: Date) {
         var newDateTime = dateTime
-        
-        if let max = tweak.maximumValue, max <= newDateTime {
-            newDateTime = max
-        } else if let min = tweak.minimumValue, min >= newDateTime {
-            newDateTime = min
-        }
-        
         self.dateTime = newDateTime
         
         if timePicker.date != newDateTime {
@@ -136,9 +129,6 @@ class DateTimePickerView: UIView {
         let picker = UIDatePicker()
         picker.backgroundColor = .white
         picker.datePickerMode = .time
-		// NOTE: It seems like we should be able to use `.valueChanged` here, but for some reason that's
-		// not firing when the value changes, so instead use `.editingDidEnd`.
-        picker.addTarget(self, action: #selector(datePickerDidChangeValue(_:)), for: .editingDidEnd)
         return picker
     }()
     
@@ -146,7 +136,6 @@ class DateTimePickerView: UIView {
         let picker = UIDatePicker()
         picker.backgroundColor = .white
         picker.datePickerMode = .date
-        picker.addTarget(self, action: #selector(datePickerDidChangeValue(_:)), for: .valueChanged)
         return picker
     }()
     
@@ -186,6 +175,10 @@ class DateTimePickerView: UIView {
         timePicker.frame = CGRect(
             origin: CGPoint(x: 0, y: timeLabel.frame.maxY),
             size: CGSize(width: bounds.width, height: 160))
+
+		timePicker.addTarget(self, action: #selector(datePickerDidChangeValue), for: .valueChanged)
+		datePicker.addTarget(self, action: #selector(datePickerDidChangeValue), for: .valueChanged)
+
     }
     
     @objc func datePickerDidChangeValue(_ picker: UIDatePicker) {

--- a/iOS Example/iOS Example/ExampleTweaks.swift
+++ b/iOS Example/iOS Example/ExampleTweaks.swift
@@ -47,6 +47,8 @@ public struct ExampleTweaks: TweakLibraryType {
 	*/
 
 	public static let featureFlagMainScreenHelperText = Tweak("Feature Flags", "Main Screen", "Show Body Text", true)
+    
+    public static let date = Tweak<Date>("Environment", "Time Warp", "Date", { Date() })
 
 	public static let defaultStore: TweakStore = {
 		let allTweaks: [TweakClusterType] = [
@@ -68,7 +70,8 @@ public struct ExampleTweaks: TweakLibraryType {
 
             actionPrintToConsole,
             
-			featureFlagMainScreenHelperText
+			featureFlagMainScreenHelperText,
+            date
 		]
 
 		// Since SwiftTweaks is a dynamic library, you'll need to determine whether tweaks are enabled.

--- a/iOS Example/iOS Example/ViewController.swift
+++ b/iOS Example/iOS Example/ViewController.swift
@@ -83,7 +83,8 @@ class ViewController: UIViewController {
             ExampleTweaks.fontSizeText1,
             ExampleTweaks.fontSizeText2,
             ExampleTweaks.horizontalMargins,
-            ExampleTweaks.verticalMargins
+            ExampleTweaks.verticalMargins,
+            ExampleTweaks.date
         ]
         
         let multipleBinding = ExampleTweaks.bindMultiple(tweaksToWatch) {


### PR DESCRIPTION
- Remove unused logic regarding min/max values for date
- Move datePicker addTarget logic outside of the init
- Add dateTweak tests for iOS Example